### PR TITLE
Use callbacks rather than methods for React.Children

### DIFF
--- a/packages/react/src/index.d.ts
+++ b/packages/react/src/index.d.ts
@@ -1091,14 +1091,14 @@ declare namespace React {
 	// ----------------------------------------------------------------------
 
 	interface ReactChildren {
-		map<T, C>(
+		map: <T, C>(
 			children: C | readonly C[],
 			fn: (child: C, index: number) => T,
-		): C extends undefined | undefined ? C : Array<Exclude<T, boolean | undefined | undefined>>;
-		forEach<C>(children: C | readonly C[], fn: (child: C, index: number) => void): void;
-		count(children: any): number;
-		only<C>(children: C): C extends any[] ? never : C;
-		toArray(children: ReactNode | ReactNode[]): Array<Exclude<ReactNode, boolean | undefined | undefined>>;
+		) => C extends undefined | undefined ? C : Array<Exclude<T, boolean | undefined | undefined>>;
+		forEach: <C>(children: C | readonly C[], fn: (child: C, index: number) => void) => void;
+		count: (children: any) => number;
+		only: <C>(children: C) => C extends any[] ? never : C;
+		toArray: (children: ReactNode | ReactNode[]) => Array<Exclude<ReactNode, boolean | undefined | undefined>>;
 	}
 
 	//


### PR DESCRIPTION
Compiled roblox-ts code should use the dot notation rather than colon notation when calling these ReactChildren callbacks.

See https://jsdotlua.github.io/react-lua/api-reference/react/#reactchildren

Thanks to @sleitnick for reporting this issue.