### PR TITLE
Improve error type

### DIFF
--- a/packages/react/src/index.d.ts
+++ b/packages/react/src/index.d.ts
@@ -487,7 +487,7 @@ declare namespace React {
 		 * Catches exceptions generated in descendant components. Unhandled exceptions will cause
 		 * the entire component tree to unmount.
 		 */
-		componentDidCatch?(error: unknown, errorInfo: ErrorInfo): void;
+		componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
 	}
 
 	// Unfortunately, we have no way of declaring that the component constructor must implement this
@@ -511,7 +511,7 @@ declare namespace React {
 		 *
 		 * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
 		 */
-		(error: any) => Partial<S> | undefined;
+		(error: Error) => Partial<S> | undefined;
 
 	// This should be "infer SS" but can't use it yet
 	interface NewLifecycle<P, S, SS> {
@@ -1104,6 +1104,12 @@ declare namespace React {
 	//
 	// Error Interfaces
 	// ----------------------------------------------------------------------
+	interface Error {
+		name: string;
+		message: string;
+		stack?: string | undefined;
+	}
+
 	interface ErrorInfo {
 		/**
 		 * Captures which component contained the exception, and its ancestors.


### PR DESCRIPTION
- [Error Type Definition in `luau-polyfill`](https://github.com/Roblox/luau-polyfill/blob/abb3cabfa9de94e6f0eca819648192b69be81ffc/modules/luau-polyfill/src/Error/Error.global.lua#L8)

This error type is currently being used in React Lua.