### PR TITLE
Improve `setState` and `None` type

### DIFF
--- a/packages/react/src/index.d.ts
+++ b/packages/react/src/index.d.ts
@@ -352,8 +352,8 @@ declare namespace React {
 		// Also, the ` | S` allows intellisense to not be dumbisense
 		setState<K extends keyof S>(
 			state:
-				| ((prevState: Readonly<S>, props: Readonly<P>) => Pick<MapToNone<S>, K> | S | undefined)
-				| (Pick<MapToNone<S>, K> | S | undefined),
+				| ((prevState: Readonly<S>, props: Readonly<P>) => Pick<MapToNone<S>, K> | MapToNone<S> | undefined)
+				| (Pick<MapToNone<S>, K> | MapToNone<S> | undefined),
 			callback?: () => void,
 		): void;
 
@@ -1016,7 +1016,16 @@ declare namespace React {
 	// Roblox Symbols
 	// ----------------------------------------------------------------------
 
-	export const None: unique symbol;
+	export const None: {
+		/**
+		 * **DO NOT USE!**
+		 *
+		 * This field exists to force TypeScript to recognize this as a nominal type
+		 * @hidden
+		 * @deprecated
+		 */
+		readonly _nominal_ReactNone: unique symbol;
+	};
 
 	//
 	// Props / DOM Attributes


### PR DESCRIPTION
This is an improvement to prevent the use of `undefined` in `setState` and to make `None` more robust by preventing the setting of other unique symbols.

```ts
this.setState({
    test: undefined // display warn - ok
})
this.setState({
    test: undefined // not display warn - bad
    numValue: "1"
})
```